### PR TITLE
Switch AWS Kinesis example to new Beam API

### DIFF
--- a/data-ingestion/pom.xml
+++ b/data-ingestion/pom.xml
@@ -63,6 +63,14 @@
             <artifactId>slf4j-jdk14</artifactId>
         </dependency>
 
+        <!-- https://github.com/apache/beam/issues/26295 -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.26</version>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/data-ingestion/pom.xml
+++ b/data-ingestion/pom.xml
@@ -28,7 +28,8 @@
 
         <dependency>
             <groupId>org.apache.beam</groupId>
-            <artifactId>beam-sdks-java-io-kinesis</artifactId>
+            <artifactId>beam-sdks-java-io-amazon-web-services2</artifactId>
+            <version>${beam.version}</version>
         </dependency>
 
         <!-- Derby JDBC driver -->

--- a/pom.xml
+++ b/pom.xml
@@ -205,12 +205,6 @@
 
             <dependency>
                 <groupId>org.apache.beam</groupId>
-                <artifactId>beam-sdks-java-io-kinesis</artifactId>
-                <version>${beam.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.beam</groupId>
                 <artifactId>beam-sdks-java-io-kudu</artifactId>
                 <version>${beam.version}</version>
             </dependency>


### PR DESCRIPTION
Old Kinesis connector is deprecated by https://github.com/apache/beam/pull/22093


## How this was tested

Run with real Kinesis:

```
$ cd data-ingestion

$ mvn clean package

$ mvn exec:java -Dexec.mainClass=org.apache.beam.samples.data.ingestion.DataToKinesis -Pdirect-runner -Dexec.args="--runner=DirectRunner --stream=stream-01" 
```